### PR TITLE
fix: upgrade semver to v3.4.0 compatible functions

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -134,7 +134,7 @@ func TestPackageMetadataResource_GetMetadata(t *testing.T) {
 			id:      "json",
 			version: "x.0.0",
 			wantFunc: func(client *Client, err error, meta *PackageSearchMetadataRegistration) {
-				wantErr := errors.New("invalid Semantic Version")
+				wantErr := errors.New("invalid semantic version")
 				require.Equal(t, wantErr, err)
 			},
 		},
@@ -248,7 +248,7 @@ func TestPackageMetadataResource_GetMetadata(t *testing.T) {
 				mustWriteHTTPResponse(t, w, fileUrl)
 			},
 			wantFunc: func(client *Client, err error, meta *PackageSearchMetadataRegistration) {
-				wantErr := errors.New("invalid Semantic Version")
+				wantErr := errors.New("invalid semantic version")
 				require.Equal(t, wantErr, err)
 			},
 		},
@@ -390,7 +390,7 @@ func TestPackageSearchMetadataRegistration(t *testing.T) {
 				Version:   "^0.0.1",
 			},
 		}
-		wantErr := errors.New("invalid Semantic Version")
+		wantErr := errors.New("invalid semantic version")
 		_, err := inputErr.Identity()
 		require.Equal(t, wantErr, err)
 	})
@@ -749,7 +749,7 @@ func TestAddMetadataToPackages(t *testing.T) {
 			wantPkgFunc: func(_ string) []*PackageSearchMetadataRegistration {
 				return emptyPkg
 			},
-			error: errors.New("invalid Semantic Version"),
+			error: errors.New("invalid semantic version"),
 		},
 		{
 			name: "invalid upper version in page return error",
@@ -764,7 +764,7 @@ func TestAddMetadataToPackages(t *testing.T) {
 			wantPkgFunc: func(_ string) []*PackageSearchMetadataRegistration {
 				return emptyPkg
 			},
-			error: errors.New("invalid Semantic Version"),
+			error: errors.New("invalid semantic version"),
 		},
 		{
 			name: "version out of range",
@@ -850,7 +850,7 @@ func TestAddMetadataToPackages(t *testing.T) {
 			wantPkgFunc: func(_ string) []*PackageSearchMetadataRegistration {
 				return emptyPkg
 			},
-			error: errors.New("invalid Semantic Version"),
+			error: errors.New("invalid semantic version"),
 		},
 		{
 			name: "includeUnlisted is false and package is unlisted return success",
@@ -982,7 +982,7 @@ func TestAddMetadataToPackages(t *testing.T) {
 				IncludePrerelease: true,
 				IncludeUnlisted:   true,
 			},
-			error: errors.New("invalid version: Invalid Semantic Version"),
+			error: errors.New("invalid version: invalid semantic version"),
 			wantPkgFunc: func(_ string) []*PackageSearchMetadataRegistration {
 				return emptyPkg
 			},

--- a/package_dependency_test.go
+++ b/package_dependency_test.go
@@ -48,7 +48,7 @@ func TestNewPackageDependencyGroup(t *testing.T) {
 					VersionRaw: "invalid_version",
 				},
 			},
-			wantError: errors.New("invalid version: Invalid Semantic Version"),
+			wantError: errors.New("invalid version: invalid semantic version"),
 		},
 	}
 
@@ -79,7 +79,7 @@ func TestNewPackageIdentity(t *testing.T) {
 			name:      "invalid version return error",
 			id:        "TestPackage",
 			version:   "invalid_version",
-			wantError: errors.New("invalid Semantic Version"),
+			wantError: errors.New("invalid semantic version"),
 		},
 	}
 
@@ -195,7 +195,7 @@ func TestConfigurePackageDependency(t *testing.T) {
 					WithIdentity(meta),
 				}
 			},
-			wantError: errors.New("invalid Semantic Version"),
+			wantError: errors.New("invalid semantic version"),
 		},
 		{
 			name: "with dependencyGroups in groups return success",

--- a/package_test.go
+++ b/package_test.go
@@ -102,7 +102,7 @@ func TestPackageResource_ListAllVersions_ErrorScenarios(t *testing.T) {
 					mustWriteHTTPResponse(t, w, fileUrl)
 				})
 			},
-			error: errors.New("invalid Semantic Version"),
+			error: errors.New("invalid semantic version"),
 		},
 	}
 	for _, tt := range tests {

--- a/search_test.go
+++ b/search_test.go
@@ -164,6 +164,10 @@ func createUrl(t *testing.T, u string) *url.URL {
 func TestParseVersionInfo(t *testing.T) {
 	symbolVersion, err := semver.NewVersion("1-0-0")
 	require.NoError(t, err)
+
+	vZeroes, err := semver.NewVersion("00000.0000.0")
+	require.NoError(t, err)
+
 	tests := []struct {
 		name    string
 		version *VersionInfo
@@ -223,7 +227,7 @@ func TestParseVersionInfo(t *testing.T) {
 			version: &VersionInfo{
 				Version: "00000.0000.0",
 			},
-			want:  NewVersion(semver.New(0, 0, 0, "", ""), 0, "00000.0000.0"),
+			want:  NewVersion(vZeroes, 0, "00000.0000.0"),
 			error: nil,
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -91,7 +91,7 @@ func ParseVersion(value string) (*Version, error) {
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("invalid Semantic Version")
+		return nil, fmt.Errorf("invalid semantic version")
 	}
 	return version, nil
 }

--- a/version_range_test.go
+++ b/version_range_test.go
@@ -234,7 +234,7 @@ func TestParseFloatingRange(t *testing.T) {
 	require.Equal(t, expectedErr, actualErr)
 
 	_, actualErr = parseFloatingRange("^*")
-	expectedErr = fmt.Errorf("invalid version in ^ range: Invalid Semantic Version")
+	expectedErr = fmt.Errorf("invalid version in ^ range: invalid semantic version")
 	require.Equal(t, expectedErr, actualErr)
 }
 


### PR DESCRIPTION
### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind documentation
/kind enhancement

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
-->
/kind failing-test

### What this PR does / why we need it:
  upgrade semver to v3.4.0 Test failure
  Ref: https://github.com/huhouhua/go-nuget/pull/15
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```